### PR TITLE
Fix multi-line go app run cmd and add support for labelling profiles

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -109,14 +109,24 @@ func tabularizeDiff(profiles []*profiler.Entry, entryGroupsByName correlatedEntr
 	t.AddHeaderGroup(1, "", table.AlignLeft)
 
 	startOffset := 1
-	for index, _ := range profiles {
+	for index, profile := range profiles {
 		baseIndex := startOffset + index*len(diffCols)
 		var groupTitle string
-		switch index {
-		case 0:
-			groupTitle = "baseline"
+		switch profile.Label {
+		case "":
+			switch index {
+			case 0:
+				groupTitle = "baseline"
+			default:
+				groupTitle = fmt.Sprintf("profile %d", index)
+			}
 		default:
-			groupTitle = fmt.Sprintf("profile %d", index)
+			switch index {
+			case 0:
+				groupTitle = fmt.Sprintf("%s - baseline", profile.Label)
+			default:
+				groupTitle = profile.Label
+			}
 		}
 		t.AddHeaderGroup(len(diffCols), groupTitle, table.AlignLeft)
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -59,7 +59,11 @@ func tabularizeProfile(profile *profiler.Entry, tableCols []tableColumnType, thr
 	t.SetPadding(1)
 
 	// Setup headers and alignment settings
-	t.SetHeader(0, "call stack", table.AlignLeft)
+	if profile.Label != "" {
+		t.SetHeader(0, fmt.Sprintf("%s - call stack", profile.Label), table.AlignLeft)
+	} else {
+		t.SetHeader(0, "call stack", table.AlignLeft)
+	}
 	for dIndex, dType := range tableCols {
 		t.SetHeader(dIndex+1, dType.Header(), table.AlignRight)
 	}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -31,7 +31,7 @@ func ProfileProject(ctx *cli.Context) error {
 		return errMissingPathToProject
 	}
 
-	profileFuncs := ctx.StringSlice("target")
+	profileFuncs := ctx.StringSlice("profile-target")
 	if len(profileFuncs) == 0 {
 		return errNoProfileTargets
 	}
@@ -81,7 +81,7 @@ func ProfileProject(ctx *cli.Context) error {
 	updatedFiles, patchCount, err := goPackage.Patch(
 		ctx.StringSlice("profile-vendored-pkg"),
 		tools.PatchCmd{profileTargets, tools.InjectProfiler()},
-		tools.PatchCmd{bootstrapTargets, tools.InjectProfilerBootstrap(ctx.String("profile-folder"))},
+		tools.PatchCmd{bootstrapTargets, tools.InjectProfilerBootstrap(ctx.String("profile-folder"), ctx.String("profile-label"))},
 	)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -23,11 +23,6 @@ func main() {
 
 			Action: cmd.ProfileProject,
 			Flags: []cli.Flag{
-				cli.StringSliceFlag{
-					Name:  "target, t",
-					Value: &cli.StringSlice{},
-					Usage: "fully qualified function name to profile",
-				},
 				cli.StringFlag{
 					Name:  "build-cmd",
 					Value: "",
@@ -47,10 +42,19 @@ func main() {
 					Name:  "preserve-output",
 					Usage: "preserve patched project post build",
 				},
+				cli.StringSliceFlag{
+					Name:  "profile-target, t",
+					Value: &cli.StringSlice{},
+					Usage: "fully qualified function name to profile",
+				},
 				cli.StringFlag{
 					Name:  "profile-folder",
 					Usage: "specify the output folder for captured profiles",
 					Value: defaultOutputDir(),
+				},
+				cli.StringFlag{
+					Name:  "profile-label",
+					Usage: `specify a label to be attached to captured profiles and displayed when using the "print" or "diff" commands`,
 				},
 				cli.StringSliceFlag{
 					Name:  "profile-vendored-pkg",

--- a/profiler/entry.go
+++ b/profiler/entry.go
@@ -10,6 +10,7 @@ import (
 type Entry struct {
 	ThreadId uint64
 
+	Label string `json:"label"`
 	Name  string `json:"name"`
 	Depth int    `json:"depth"`
 

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -19,6 +19,9 @@ var (
 	// A mutex for protecting access to the activeProfiles map.
 	profileMutex sync.Mutex
 
+	// A label to be applied to generated profiles.
+	profileLabel string
+
 	// We maintain a set of active profiles grouped by goroutine id.
 	activeProfiles map[uint64]*Entry
 
@@ -53,7 +56,7 @@ func LoadProfile(file string) (*Entry, error) {
 }
 
 // Initialize profiler. This method must be called before invoking any other method from this package.
-func Init(sink Sink) {
+func Init(sink Sink, capturedProfileLabel string) {
 	err := sink.Open(defaultSinkBufferSize)
 	if err != nil {
 		err = fmt.Errorf("profiler: error initializing sink: %s", err)
@@ -62,6 +65,7 @@ func Init(sink Sink) {
 
 	outputSink = sink
 	activeProfiles = make(map[uint64]*Entry, 0)
+	profileLabel = capturedProfileLabel
 }
 
 // Wait for shippers to fully dequeue any buffered profiles and shut them down.
@@ -84,6 +88,7 @@ func BeginProfile(name string) {
 
 	tid := threadId()
 	pe := makeEntry(name, 0)
+	pe.Label = profileLabel
 	activeProfiles[tid] = pe
 	pe.ThreadId = tid
 	pe.EnteredAt = time.Now()

--- a/tools/injector.go
+++ b/tools/injector.go
@@ -12,7 +12,7 @@ var (
 )
 
 // Return a PatchFunc that injects our profiler init code the main function of the target package.
-func InjectProfilerBootstrap(profileDir string) PatchFunc {
+func InjectProfilerBootstrap(profileDir, profileLabel string) PatchFunc {
 	return func(cgNode *CallGraphNode, fnDeclNode *ast.BlockStmt) (modifiedAST bool, extraImports []string) {
 		imports := append(profilerImports, sinkImports...)
 		fnDeclNode.List = append(
@@ -21,7 +21,7 @@ func InjectProfilerBootstrap(profileDir string) PatchFunc {
 					&ast.BasicLit{
 						token.NoPos,
 						token.STRING,
-						fmt.Sprintf("prismProfiler.Init(prismSink.NewFileSink(%q))", profileDir),
+						fmt.Sprintf("prismProfiler.Init(prismSink.NewFileSink(%q), %q)", profileDir, profileLabel),
 					},
 				},
 				&ast.ExprStmt{


### PR DESCRIPTION
This PR fixes a bug introduced by https://github.com/geckoboard/prism/commit/1ed83652a9b6a3e73cad541487ae3e09c0ba08fb where the default `-run-cmd` argument failed to correctly select the non-test go files due to not being properly escaped.

In addition, this PR makes the `profile` command argument names more uniform and introduces the `-profile-label` argument that enables users to assign a label to the collected profiles. These labels will be automatically displayed when invoking the `print` or `diff` commands.
