### PR TITLE
Feature make overhead tracking even more accurate

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -12,7 +12,7 @@ func TestProfiler(t *testing.T) {
 	sink := newBufferedSink()
 	Init(sink, "profiler-test")
 
-	BeginProfile("func1", time.Now())
+	BeginProfile("func1")
 	<-time.After(5 * time.Millisecond)
 
 	// Invoke EndProfile/Enter/Leave from a different go-routine. These
@@ -28,13 +28,13 @@ func TestProfiler(t *testing.T) {
 				// profile data collected by the other goroutine
 				defer EndProfile()
 			} else {
-				Enter(nestedCallName, time.Now())
+				Enter(nestedCallName)
 				defer Leave()
 			}
 		}(depth)
 	}
 
-	Enter(nestedCallName, time.Now())
+	Enter(nestedCallName)
 	<-time.After(10 * time.Millisecond)
 	Leave()
 

--- a/tools/injector.go
+++ b/tools/injector.go
@@ -52,7 +52,7 @@ func InjectProfiler() PatchFunc {
 					X: &ast.BasicLit{
 						ValuePos: token.NoPos,
 						Kind:     token.STRING,
-						Value:    fmt.Sprintf(`prismProfiler.%s("%s", prismProfiler.Time())`, enterFn, cgNode.Name),
+						Value:    fmt.Sprintf(`prismProfiler.%s("%s")`, enterFn, cgNode.Name),
 					},
 				},
 				&ast.ExprStmt{

--- a/tools/injector_test.go
+++ b/tools/injector_test.go
@@ -82,7 +82,7 @@ func TestInjectProfiler(t *testing.T) {
 	}
 
 	expStmts := []string{
-		fmt.Sprintf("prismProfiler.Enter(%q, prismProfiler.Time())", cgNode.Name),
+		fmt.Sprintf("prismProfiler.Enter(%q)", cgNode.Name),
 		"defer prismProfiler.Leave()",
 	}
 	for stmtIndex, expStmt := range expStmts {


### PR DESCRIPTION
The profiler used to track its overhead using a tick := time.Now() at the profiler method start and time.Since(tick) statement at the method's end. This approach however fails to account for the actual time spent invoking the profiler hook (stack setup, register push on entry/pop on exit) or the time spent invoking time.Now() and time.Since().

The actual overhead is in the nanosecond range but causes a significant skew in the total time measurements if the profiled function is invoked a large number of times.

This PR attempts to improve the tracking of overhead by using a calibration loop to estimate the mean time required for time.Now/Since and runtime overhead for invoking profiler methods and factoring that time in overhead calculations.

Since we are using the mean time, our calculations are still not 100% accurate but allow us to reduce our skew to ~40ms for a method invoked 1M times (~40ns untracked overhead per call).